### PR TITLE
Show unconfirmed transactions in `TransactionView` and `WalletView`

### DIFF
--- a/transaction.py
+++ b/transaction.py
@@ -69,9 +69,10 @@ class TransactionView(view.View):
         CYELLOW = curses.color_pair(5)
         CBOLD = curses.A_BOLD
 
-        self._pad.addstr(0, 1, "time {}".format(
-            isoformatseconds(datetime.datetime.utcfromtimestamp(transaction["time"]))
-        ), CBOLD)
+        if "time" in transaction:
+            self._pad.addstr(0, 1, "time {}".format(
+                isoformatseconds(datetime.datetime.utcfromtimestamp(transaction["time"]))
+            ), CBOLD)
         self._pad.addstr(1, 1, "size {}b".format(transaction["size"]), CBOLD)
         self._pad.addstr(1, 15, "vsize {}b".format(transaction["vsize"]), CBOLD)
         self._pad.addstr(2, 1, "locktime {}".format(transaction["locktime"]), CBOLD)

--- a/wallet.py
+++ b/wallet.py
@@ -59,7 +59,8 @@ class WalletView(view.View):
                 self._pad.addstr(2+((i-offset)*3), 1, "{}".format(
                     isoformatseconds(datetime.datetime.utcfromtimestamp(tx["timereceived"]))
                 ), color)
-                self._pad.addstr(2+((i-offset)*3), 30, "block: {: 7d}".format(tx["blockindex"]), color)
+                if "blockindex" in tx:
+                    self._pad.addstr(2+((i-offset)*3), 30, "block: {: 7d}".format(tx["blockindex"]), color)
                 self._pad.addstr(2+((i-offset)*3), 81, "{: 15.8f} BTC".format(
                     tx["amount"],
                 ), color)


### PR DESCRIPTION
After issuing a `sendtoaddress` command to `bitcoin-cli`, a wallet may contain unconfirmed transactions.   
This pull request prevents a KeyError to be raised when the wallet or the transactions are viewed.